### PR TITLE
GRHB-92: * fix protected route redirection

### DIFF
--- a/frontend/src/components/app/app.tsx
+++ b/frontend/src/components/app/app.tsx
@@ -1,4 +1,4 @@
-import { AppRoute, StorageKey } from 'common/enums/enums';
+import { AppRoute, DataStatus, StorageKey } from 'common/enums/enums';
 import { FC } from 'common/types/types';
 import { Auth } from 'components/auth/auth';
 import {
@@ -6,14 +6,16 @@ import {
   ProtectedRoute,
   Route,
   Routes,
+  Spinner,
 } from 'components/common/common';
 import { UAM } from 'components/uam/uam';
-import { useAppDispatch } from 'hooks/hooks';
+import { useAppDispatch, useAppSelector } from 'hooks/hooks';
 import { useEffect } from 'react';
 import { storage } from 'services/services';
 import { authActions } from 'store/actions';
 
 const App: FC = () => {
+  const { user, dataStatus } = useAppSelector((state) => state.auth);
   const dispatch = useAppDispatch();
 
   const token = Boolean(storage.getItem(StorageKey.TOKEN));
@@ -23,6 +25,10 @@ const App: FC = () => {
       dispatch(authActions.getCurrentUser());
     }
   }, [dispatch, token]);
+
+  if (!user && token && dataStatus !== DataStatus.REJECTED) {
+    return <Spinner />;
+  }
 
   return (
     <>

--- a/frontend/src/components/app/app.tsx
+++ b/frontend/src/components/app/app.tsx
@@ -18,15 +18,16 @@ const App: FC = () => {
   const { user, dataStatus } = useAppSelector((state) => state.auth);
   const dispatch = useAppDispatch();
 
-  const token = Boolean(storage.getItem(StorageKey.TOKEN));
+  const hasUser = Boolean(user);
+  const hasToken = Boolean(storage.getItem(StorageKey.TOKEN));
 
   useEffect(() => {
-    if (token) {
+    if (hasToken) {
       dispatch(authActions.getCurrentUser());
     }
-  }, [dispatch, token]);
+  }, [dispatch, hasToken]);
 
-  if (!user && token && dataStatus !== DataStatus.REJECTED) {
+  if (!hasUser && hasToken && dataStatus !== DataStatus.REJECTED) {
     return <Spinner />;
   }
 

--- a/frontend/src/components/common/protected-route/protected-route.tsx
+++ b/frontend/src/components/common/protected-route/protected-route.tsx
@@ -1,8 +1,9 @@
-import { AppRoute } from 'common/enums/enums';
+import { AppRoute, DataStatus, StorageKey } from 'common/enums/enums';
 import { FC } from 'common/types/types';
 import { Navigate } from 'components/common/common';
 import { useAppSelector } from 'hooks/hooks';
 import { ReactNode } from 'react';
+import { storage } from 'services/services';
 
 type Props = {
   redirectTo?: AppRoute;
@@ -13,13 +14,17 @@ const ProtectedRoute: FC<Props> = ({
   redirectTo = AppRoute.SIGN_IN,
   component,
 }) => {
-  const { user } = useAppSelector(({ auth }) => ({
-    user: auth.user,
-  }));
+  const { user, dataStatus } = useAppSelector((state) => state.auth);
 
   const hasUser = Boolean(user);
+  const token = Boolean(storage.getItem(StorageKey.TOKEN));
 
-  if (!hasUser) {
+  if (
+    !token ||
+    (!hasUser &&
+      (dataStatus === DataStatus.FULFILLED ||
+        dataStatus === DataStatus.REJECTED))
+  ) {
     return <Navigate to={redirectTo} />;
   }
 

--- a/frontend/src/components/common/protected-route/protected-route.tsx
+++ b/frontend/src/components/common/protected-route/protected-route.tsx
@@ -1,9 +1,8 @@
-import { AppRoute, DataStatus, StorageKey } from 'common/enums/enums';
+import { AppRoute } from 'common/enums/enums';
 import { FC } from 'common/types/types';
 import { Navigate } from 'components/common/common';
 import { useAppSelector } from 'hooks/hooks';
 import { ReactNode } from 'react';
-import { storage } from 'services/services';
 
 type Props = {
   redirectTo?: AppRoute;
@@ -14,16 +13,11 @@ const ProtectedRoute: FC<Props> = ({
   redirectTo = AppRoute.SIGN_IN,
   component,
 }) => {
-  const { user, dataStatus } = useAppSelector((state) => state.auth);
+  const { user } = useAppSelector((state) => state.auth);
 
-  const token = Boolean(storage.getItem(StorageKey.TOKEN));
   const hasUser = Boolean(user);
-  const hasLoaded =
-    !token ||
-    dataStatus === DataStatus.FULFILLED ||
-    dataStatus === DataStatus.REJECTED;
 
-  if (!hasUser && hasLoaded) {
+  if (!hasUser) {
     return <Navigate to={redirectTo} />;
   }
 

--- a/frontend/src/components/common/protected-route/protected-route.tsx
+++ b/frontend/src/components/common/protected-route/protected-route.tsx
@@ -16,15 +16,14 @@ const ProtectedRoute: FC<Props> = ({
 }) => {
   const { user, dataStatus } = useAppSelector((state) => state.auth);
 
-  const hasUser = Boolean(user);
   const token = Boolean(storage.getItem(StorageKey.TOKEN));
-
-  if (
+  const hasUser = Boolean(user);
+  const hasLoaded =
     !token ||
-    (!hasUser &&
-      (dataStatus === DataStatus.FULFILLED ||
-        dataStatus === DataStatus.REJECTED))
-  ) {
+    dataStatus === DataStatus.FULFILLED ||
+    dataStatus === DataStatus.REJECTED;
+
+  if (!hasUser && hasLoaded) {
     return <Navigate to={redirectTo} />;
   }
 


### PR DESCRIPTION
Protected Route was redirecting the signed user to the sign-in
The reason of adding token check is that `getCurrentUser()` is not called, if there's no token. In that case, `dataStatus` stays `DataStatus.IDLE`. And because of that it doesn't seem possible to differentiate the initial state `{user: null, dataStatus: DataStatus.IDLE}` and the state for the user with no token  `{user: null, dataStatus: DataStatus.IDLE}`
Another option would be to change `dataStatus` to `DataStatus.FULFILLED` in case where there's no token. Should I do that?