### PR TITLE
grhb-139:  change background-color of main content style of authorized-wrapper component

### DIFF
--- a/frontend/src/components/common/authorized-wrapper/styles.module.scss
+++ b/frontend/src/components/common/authorized-wrapper/styles.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-grow: 1;
   min-height: 0;
+  background: var(--background-gray-400);
 }
 
 .mainContent {

--- a/frontend/src/components/uam/styles.module.scss
+++ b/frontend/src/components/uam/styles.module.scss
@@ -5,7 +5,6 @@
   align-items: center;
   width: 100%;
   padding: 20px;
-  background: var(--background-gray-400);
 }
 
 .pageTitle {


### PR DESCRIPTION
Chrome & Firefox:

<img width="1791" alt="Screen Shot 2022-08-15 at 3 18 08 PM" src="https://user-images.githubusercontent.com/36548565/184634791-964d9d2f-0305-4b31-b182-168cb29a6617.png">

<img width="1791" alt="Screen Shot 2022-08-15 at 3 16 15 PM" src="https://user-images.githubusercontent.com/36548565/184634799-f6e3ef58-4c14-4a8e-aa3b-9623d6921ed9.png">
