### PR TITLE
GRHB-120: * fix add padding to the content

### DIFF
--- a/mobile/src/components/uam-groups-create/uam-groups-create.tsx
+++ b/mobile/src/components/uam-groups-create/uam-groups-create.tsx
@@ -71,32 +71,34 @@ const UAMGroupsCreate: FC = () => {
   return (
     <View style={styles.container}>
       <ScrollView>
-        <View style={styles.inputContainer}>
-          <Input
-            name="name"
-            placeholder="Enter group name"
-            label="Group name"
-            control={control}
-            errors={errors}
-          />
-        </View>
+        <View style={styles.innerContainer}>
+          <View style={styles.inputContainer}>
+            <Input
+              name="name"
+              placeholder="Enter group name"
+              label="Group name"
+              control={control}
+              errors={errors}
+            />
+          </View>
 
-        <Text style={styles.title}>Add users to the Group - Optional</Text>
-        <UsersTable
-          users={users}
-          onCheckbox={handleToggleUsers}
-          pagination={paginationForUsersTable}
-        />
-        <Text style={styles.title}>Attach permissions policies</Text>
-        <GroupsTable
-          permissions={permissions.items}
-          onCheckbox={handleTogglePermissions}
-        />
-        <View style={styles.buttonsContainer}>
-          <Button
-            label="Create group"
-            onPress={handleSubmit(handleCreateGroup)}
+          <Text style={styles.title}>Add users to the Group - Optional</Text>
+          <UsersTable
+            users={users}
+            onCheckbox={handleToggleUsers}
+            pagination={paginationForUsersTable}
           />
+          <Text style={styles.title}>Attach permissions policies</Text>
+          <GroupsTable
+            permissions={permissions.items}
+            onCheckbox={handleTogglePermissions}
+          />
+          <View style={styles.buttonsContainer}>
+            <Button
+              label="Create group"
+              onPress={handleSubmit(handleCreateGroup)}
+            />
+          </View>
         </View>
       </ScrollView>
     </View>


### PR DESCRIPTION
1) [Bug](https://trello.com/c/teTR10tI/219-add-padding-to-create-group-screen)
2) Expected result: Page has the same left and right padding as the UAM page
3) <img src="https://user-images.githubusercontent.com/82529236/185732440-132ec1d9-6278-4972-bc82-ff7261722808.png" width="40%">