### PR TITLE
GRHB-217: * make columns in users and groups table narrower

### DIFF
--- a/mobile/src/components/uam/groups-table/groups-table.tsx
+++ b/mobile/src/components/uam/groups-table/groups-table.tsx
@@ -42,7 +42,7 @@ const GroupsTable: FC = () => {
     <View style={styles.container}>
       <Text style={styles.title}>Groups</Text>
       <Table
-        columnWidthArr={[50, 250, 250, 150]}
+        columnWidthArr={[50, 210, 250, 150]}
         columns={groupsColumns}
         data={groupsRows}
       />

--- a/mobile/src/components/uam/users-table/users-table.tsx
+++ b/mobile/src/components/uam/users-table/users-table.tsx
@@ -46,7 +46,7 @@ const UsersTable: FC = () => {
         <Table
           columns={usersColumns}
           data={tableData}
-          columnWidthArr={[50, 250, 250, 150, 150]}
+          columnWidthArr={[50, 210, 250, 150, 100]}
         />
       </View>
       <Pagination


### PR DESCRIPTION
Made the second column in users and groups tables narrower a little.
Didn't bind column width to content size, because, from my point of view, fixed columns width design is more user friendly