### PR TITLE
GRHB-234: * fixed image container grow

### DIFF
--- a/frontend/src/components/course/styles.module.scss
+++ b/frontend/src/components/course/styles.module.scss
@@ -15,7 +15,7 @@
 }
 
 .image {
-  height: 60vh;
+  width: 80%;
   overflow: hidden;
   border-radius: 12px;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78655088/185878613-c3c4f2e0-2ae6-42aa-821a-523d105dae58.png)

Issue is fixed. Now there's no empty space on smaller screens.