### PR TITLE
GRHB231: Fields aren't cleared after second open of group creation screen (mobile)

### DIFF
--- a/mobile/src/components/uam-configure-group/components/permissions-table/permissions-table.tsx
+++ b/mobile/src/components/uam-configure-group/components/permissions-table/permissions-table.tsx
@@ -36,7 +36,7 @@ const PermissionsTable: FC<Props> = ({
 
   useFocusEffect(
     useCallback(() => {
-      reset({});
+      return () => reset({});
     }, []),
   );
 

--- a/mobile/src/components/uam-configure-group/components/permissions-table/permissions-table.tsx
+++ b/mobile/src/components/uam-configure-group/components/permissions-table/permissions-table.tsx
@@ -7,7 +7,7 @@ import {
   getPermissionsColumns,
   getPermissionsRows,
 } from '~/components/uam-configure-group/helpers/helpers';
-import { useAppForm } from '~/hooks/hooks';
+import { useAppForm, useCallback, useFocusEffect } from '~/hooks/hooks';
 
 import { styles } from './styles';
 
@@ -25,7 +25,7 @@ const PermissionsTable: FC<Props> = ({
   onCheckboxToggle,
   pagination,
 }) => {
-  const { control } = useAppForm({ defaultValues: {} });
+  const { control, reset } = useAppForm({ defaultValues: {} });
 
   const permissionRows = getPermissionsRows({
     permissions: permissions,
@@ -33,6 +33,12 @@ const PermissionsTable: FC<Props> = ({
     control,
   });
   const permissionColumns = getPermissionsColumns();
+
+  useFocusEffect(
+    useCallback(() => {
+      reset({});
+    }, []),
+  );
 
   return (
     <View style={styles.container}>

--- a/mobile/src/components/uam-configure-group/components/users-table/users-table.tsx
+++ b/mobile/src/components/uam-configure-group/components/users-table/users-table.tsx
@@ -34,7 +34,7 @@ const UsersTable: FC<Props> = ({ users, onCheckboxToggle, pagination }) => {
 
   useFocusEffect(
     useCallback(() => {
-      reset({});
+      return () => reset({});
     }, []),
   );
 

--- a/mobile/src/components/uam-configure-group/components/users-table/users-table.tsx
+++ b/mobile/src/components/uam-configure-group/components/users-table/users-table.tsx
@@ -7,7 +7,7 @@ import {
   getUserColumns,
   getUserRows,
 } from '~/components/uam-configure-group/helpers/helpers';
-import { useAppForm } from '~/hooks/hooks';
+import { useAppForm, useCallback, useFocusEffect } from '~/hooks/hooks';
 
 import { styles } from './styles';
 
@@ -24,13 +24,19 @@ type Props = {
 };
 
 const UsersTable: FC<Props> = ({ users, onCheckboxToggle, pagination }) => {
-  const { control } = useAppForm({ defaultValues: {} });
+  const { control, reset } = useAppForm({ defaultValues: {} });
   const userRows = getUserRows({
     users: users.items,
     onToggle: onCheckboxToggle,
     control,
   });
   const userColumns = getUserColumns();
+
+  useFocusEffect(
+    useCallback(() => {
+      reset({});
+    }, []),
+  );
 
   return (
     <View style={styles.container}>

--- a/mobile/src/components/uam-configure-group/uam-configure-group.tsx
+++ b/mobile/src/components/uam-configure-group/uam-configure-group.tsx
@@ -132,7 +132,7 @@ const UAMConfigureGroup: FC = () => {
 
   useFocusEffect(
     useCallback(() => {
-      reset({ name: '' });
+      return () => reset({ name: '' });
     }, []),
   );
 

--- a/mobile/src/components/uam-configure-group/uam-configure-group.tsx
+++ b/mobile/src/components/uam-configure-group/uam-configure-group.tsx
@@ -18,7 +18,9 @@ import {
   useAppForm,
   useAppNavigate,
   useAppSelector,
+  useCallback,
   useEffect,
+  useFocusEffect,
   usePagination,
   useSelectedItems,
 } from '~/hooks/hooks';
@@ -127,6 +129,12 @@ const UAMConfigureGroup: FC = () => {
       reset({ name: group.name });
     }
   }, [group]);
+
+  useFocusEffect(
+    useCallback(() => {
+      reset({ name: '' });
+    }, []),
+  );
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
1) Bug: [Fields aren't cleared after second open of group creation screen (mobile)](https://trello.com/c/TpYUBhlb/231-fields-arent-cleared-after-second-open-of-group-creation-screen)
2) <img src="https://user-images.githubusercontent.com/82529236/185917807-412428f0-7480-48b0-ab98-16eb1fb7c3ce.gif" width="35%">
 