### PR TITLE
GRHB-260: Misspelled group update success message

### DIFF
--- a/frontend/src/common/enums/notification/notification-messages/notification-message.enum.ts
+++ b/frontend/src/common/enums/notification/notification-messages/notification-message.enum.ts
@@ -1,6 +1,6 @@
 enum NotificationMessage {
-  GROUP_CREATE = 'Group has been succeffully created!',
-  GROUP_UPDATE = 'Group has been succeffully updated!',
+  GROUP_CREATE = 'Group has been successfully created!',
+  GROUP_UPDATE = 'Group has been successfully updated!',
   MODULE_NOT_FOUND = 'Module not found!',
 }
 


### PR DESCRIPTION
Also fixed wrong spelling of successful create group message
![image](https://user-images.githubusercontent.com/88377450/186081939-81dcbd59-ec99-4531-bba4-584ba142acdf.png)
![image](https://user-images.githubusercontent.com/88377450/186082124-f51fdf72-b568-4198-9e15-6278fa42636d.png)
