### PR TITLE
GRHB-297: "Select category" dropdown menu isn't displayed at the "Change category" pop-up menu after clicking on the "Arrow Icon"

### DIFF
--- a/frontend/src/components/common/select/styles.module.scss
+++ b/frontend/src/components/common/select/styles.module.scss
@@ -38,6 +38,8 @@
 }
 
 .selectWrapper::after {
+  position: absolute;
+  right: 10px;
   content: '';
   justify-self: end;
   width: 15px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/88377450/187200352-234b5dbd-3fb1-4a98-9b3e-003110a11eb9.png)
