### PR TITLE
GRHB-273: * fixed modal not being closed after adding course

### DIFF
--- a/frontend/src/components/dashboard/components/add-course-modal/add-course-modal.tsx
+++ b/frontend/src/components/dashboard/components/add-course-modal/add-course-modal.tsx
@@ -22,7 +22,9 @@ const AddCourseModal: FC<Props> = ({ isModalOpen, onModalToggle }) => {
   const dispatch = useAppDispatch();
 
   const onSubmit = (payload: CourseCreateRequestDto): void => {
-    dispatch(dashboardActions.addCourse(payload)).unwrap().then(onModalToggle);
+    dispatch(dashboardActions.addCourse(payload))
+      .unwrap()
+      .then(() => onModalToggle());
   };
 
   return (

--- a/frontend/src/components/dashboard/dashboard.tsx
+++ b/frontend/src/components/dashboard/dashboard.tsx
@@ -38,7 +38,10 @@ const Dashboard: FC = () => {
   }
 
   const handleNewCourseModalToggle = (evt: React.MouseEvent | void): void => {
-    evt?.stopPropagation();
+    if (evt && evt.target) {
+      evt.stopPropagation();
+    }
+
     setIsNewCourseModalOpen(!isNewCourseModalOpen);
   };
 

--- a/frontend/src/components/dashboard/dashboard.tsx
+++ b/frontend/src/components/dashboard/dashboard.tsx
@@ -38,10 +38,7 @@ const Dashboard: FC = () => {
   }
 
   const handleNewCourseModalToggle = (evt: React.MouseEvent | void): void => {
-    if (evt && evt.target) {
-      evt.stopPropagation();
-    }
-
+    evt?.stopPropagation();
     setIsNewCourseModalOpen(!isNewCourseModalOpen);
   };
 


### PR DESCRIPTION
Previously we were calling the function to close the modal with data that was returned from creating course (so were passing a course to the close function). I've added some event-related checks, but not sure if it is a good way.  