### PR TITLE
GRHB-258: + clickable row

### DIFF
--- a/frontend/src/components/common/table/styles.module.scss
+++ b/frontend/src/components/common/table/styles.module.scss
@@ -40,3 +40,11 @@
   font-size: 18px;
   text-align: center;
 }
+
+.row {
+  cursor: pointer;
+}
+
+.row:hover {
+  background-color: var(--background-gray-400);
+}

--- a/frontend/src/components/common/table/table.tsx
+++ b/frontend/src/components/common/table/table.tsx
@@ -1,3 +1,4 @@
+import { getValidClasses } from 'helpers/helpers';
 import { ReactElement } from 'react';
 import { Column, useTable } from 'react-table';
 
@@ -7,12 +8,14 @@ type Props<Data extends Record<string, unknown>> = {
   columns: Column<Data>[];
   data: readonly Data[];
   placeholder?: string;
+  onRowClick?: (row: Data) => void;
 };
 
 const Table = <Data extends Record<string, unknown>>({
   columns,
   data,
   placeholder = 'No data to display',
+  onRowClick,
 }: Props<Data>): ReactElement => {
   const tableInstance = useTable({
     columns,
@@ -47,9 +50,16 @@ const Table = <Data extends Record<string, unknown>>({
       <tbody {...getTableBodyProps()}>
         {rows.map((row) => {
           prepareRow(row);
+          const handleRowClick = (): void => {
+            onRowClick?.(row.original);
+          };
 
           return (
-            <tr {...row.getRowProps()}>
+            <tr
+              {...row.getRowProps()}
+              onClick={handleRowClick}
+              className={getValidClasses(onRowClick && styles.row)}
+            >
               {row.cells.map((cell) => {
                 return (
                   <td

--- a/frontend/src/components/interview/components/other-applications-table/other-applications-table.tsx
+++ b/frontend/src/components/interview/components/other-applications-table/other-applications-table.tsx
@@ -1,4 +1,4 @@
-import { PaginationDefaultValue } from 'common/enums/enums';
+import { AppRoute, PaginationDefaultValue } from 'common/enums/enums';
 import { FC, InterviewsGetOtherItemResponseDto } from 'common/types/types';
 import { Pagination, Table } from 'components/common/common';
 import { OtherApplicationsTableRow } from 'components/interview/common/types/types';
@@ -6,7 +6,7 @@ import {
   getOtherApplicationsColumns,
   getOtherApplicationsRows,
 } from 'components/interview/components/other-applications-table/helpers/helpers';
-import { useMemo } from 'hooks/hooks';
+import { useMemo, useNavigate } from 'hooks/hooks';
 import { Column } from 'react-table';
 
 type Props = {
@@ -22,6 +22,7 @@ const OtherApplicationsTable: FC<Props> = ({
   onPageChange,
   totalOtherInterviewsNumber,
 }) => {
+  const navigate = useNavigate();
   const columns = useMemo<Column<OtherApplicationsTableRow>[]>(() => {
     return getOtherApplicationsColumns();
   }, []);
@@ -30,9 +31,13 @@ const OtherApplicationsTable: FC<Props> = ({
     return getOtherApplicationsRows(interviews);
   }, [interviews]);
 
+  const handleRowClick = (row: OtherApplicationsTableRow): void => {
+    navigate(`${AppRoute.INTERVIEW}/${row.id}`);
+  };
+
   return (
     <div>
-      <Table data={data} columns={columns} />
+      <Table data={data} columns={columns} onRowClick={handleRowClick} />
       <Pagination
         currentPage={page}
         onPageChange={onPageChange}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61088675/187361348-e7ce42b0-5425-4f55-bae5-01e0aaef2356.png)
QA requested to make row clickable, so that it redirects to the page of an interview.
Small note about styling: used `getValidClasses(onRowClick && styles.row)` so that the row doesn't seem clickable, if it is not.
Also, not quite sure about passing `onClick` to `tr`, but also don't think, that wrapping it around the button is an option (since the row is not always clickable). And [here](https://github.com/TanStack/table/discussions/2295#discussioncomment-12540) `onClick` is being attached to `tr`, so I guess that's okay