### PR TITLE
GRHB-302: * fixed categories recolor on search

### DIFF
--- a/frontend/src/components/common/category/category.tsx
+++ b/frontend/src/components/common/category/category.tsx
@@ -2,6 +2,7 @@ import { StringCase } from 'common/enums/enums';
 import { FC } from 'common/types/types';
 import { Image } from 'components/common/common';
 import { changeStringCase } from 'helpers/helpers';
+import { useMemo } from 'hooks/hooks';
 
 import { getRandomColor } from './helpers/helpers';
 import styles from './styles.module.scss';
@@ -17,8 +18,12 @@ const Category: FC<Props> = ({ keyName, name }) => {
     caseType: StringCase.KEBAB_CASE,
   });
 
+  const color = useMemo(() => {
+    return getRandomColor();
+  }, []);
+
   return (
-    <div className={styles.category} style={{ borderColor: getRandomColor() }}>
+    <div className={styles.category} style={{ borderColor: color }}>
       <Image
         width="30px"
         height="30px"

--- a/frontend/src/components/dashboard/dashboard.tsx
+++ b/frontend/src/components/dashboard/dashboard.tsx
@@ -38,31 +38,6 @@ const Dashboard: FC = () => {
     setIsNewCourseModalOpen(!isNewCourseModalOpen);
   };
 
-  if (dataStatus === DataStatus.PENDING) {
-    return (
-      <div className={styles.dashboard}>
-        <div className={styles.headerWrapper}>
-          <div className={styles.header}>
-            <h1 className={styles.headingText}>Courses</h1>
-            {hasUser && (
-              <Button
-                label="+ Add new course"
-                btnColor="blue"
-                onClick={handleNewCourseModalToggle}
-              />
-            )}
-            <AddCourseModal
-              isModalOpen={isNewCourseModalOpen}
-              onModalToggle={handleNewCourseModalToggle}
-            />
-          </div>
-          <CategoriesList items={categories} />
-        </div>
-        <Spinner />
-      </div>
-    );
-  }
-
   return (
     <div className={styles.dashboard}>
       <div className={styles.headerWrapper}>
@@ -82,7 +57,11 @@ const Dashboard: FC = () => {
         </div>
         <CategoriesList items={categories} />
       </div>
-      <CoursesList courses={courses} />
+      {dataStatus === DataStatus.PENDING ? (
+        <Spinner />
+      ) : (
+        <CoursesList courses={courses} />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/dashboard/dashboard.tsx
+++ b/frontend/src/components/dashboard/dashboard.tsx
@@ -33,14 +33,35 @@ const Dashboard: FC = () => {
     dispatch(dashboardActions.getCategories());
   }, [dispatch]);
 
-  if (dataStatus === DataStatus.PENDING) {
-    return <Spinner />;
-  }
-
   const handleNewCourseModalToggle = (evt: React.MouseEvent | void): void => {
     evt?.stopPropagation();
     setIsNewCourseModalOpen(!isNewCourseModalOpen);
   };
+
+  if (dataStatus === DataStatus.PENDING) {
+    return (
+      <div className={styles.dashboard}>
+        <div className={styles.headerWrapper}>
+          <div className={styles.header}>
+            <h1 className={styles.headingText}>Courses</h1>
+            {hasUser && (
+              <Button
+                label="+ Add new course"
+                btnColor="blue"
+                onClick={handleNewCourseModalToggle}
+              />
+            )}
+            <AddCourseModal
+              isModalOpen={isNewCourseModalOpen}
+              onModalToggle={handleNewCourseModalToggle}
+            />
+          </div>
+          <CategoriesList items={categories} />
+        </div>
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.dashboard}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78655088/187435083-9a8f577b-f0ee-405c-aa9a-209d0d68b24a.png)

I have a proposition: I think we should make 'Spinner' component affect only course list (as on screenshot). Because before when we were searching for a course, 'Spinner' also affected page title, 'add' button and category list -> it caused everything to rerender including recoloring of categories. In my opinion that's not relevant because it's expected to just the course list being loaded. 
In this way we also fix [this](https://trello.com/c/ksm7f9C2/301-course-categories-border-color-is-calculating-twice-at-the-dashboard-during-page-loading) problem.

I didn't find a way how to fix the problem without my proposition. What do you guys think about it? Maybe I am wrong?