### PR TITLE
GRHB-350: * added preserving of line breaks in notes, moved date to the bottom

### DIFF
--- a/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/interview-note-card.tsx
+++ b/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/interview-note-card.tsx
@@ -15,7 +15,7 @@ const InterviewNoteCard: FC<Props> = ({ note, authorName, postDate }) => {
   return (
     <div className={styles.card}>
       <p className={styles.noteContent}>{note}</p>
-      <div className={styles.cardContentWrapper}>
+      <div className={styles.cardInfoWrapper}>
         <div className={styles.cardAuthorSection}>
           <Image
             width="30px"

--- a/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/interview-note-card.tsx
+++ b/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/interview-note-card.tsx
@@ -14,21 +14,21 @@ type Props = {
 const InterviewNoteCard: FC<Props> = ({ note, authorName, postDate }) => {
   return (
     <div className={styles.card}>
+      <p className={styles.noteContent}>{note}</p>
       <div className={styles.cardContentWrapper}>
-        <p className={styles.noteContent}>{note}</p>
+        <div className={styles.cardAuthorSection}>
+          <Image
+            width="30px"
+            height="30px"
+            src={defaultAvatar}
+            alt="Author avatar"
+            isCircular
+          />
+          <div className={styles.authorNameSection}>{authorName}</div>
+        </div>
         <div className={styles.postDateSection}>
           <div>{getFormattedDate(postDate, 'HH:mm, dd.MM')}</div>
         </div>
-      </div>
-      <div className={styles.cardAuthorSection}>
-        <Image
-          width="30px"
-          height="30px"
-          src={defaultAvatar}
-          alt="Author avatar"
-          isCircular
-        />
-        <div className={styles.authorNameSection}>{authorName}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/styles.module.scss
+++ b/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/styles.module.scss
@@ -28,5 +28,7 @@
 }
 
 .noteContent {
+  margin: 6px;
+  white-space: pre-wrap;
   word-break: break-all;
 }

--- a/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/styles.module.scss
+++ b/frontend/src/components/interview/components/history-section/components/interview-note-cards-list/components/interview-note-card/styles.module.scss
@@ -9,7 +9,7 @@
   border-radius: 20px;
 }
 
-.cardContentWrapper {
+.cardInfoWrapper {
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
I also moved the date to the bottom as it looked not very nice with a bit longer notes. 
Used to be: 
<img width="379" alt="Screenshot 2022-09-06 at 10 15 40" src="https://user-images.githubusercontent.com/25983129/188574050-637d0186-e7f5-42ac-8a96-90047cb6a085.png">

Is now:  
<img width="378" alt="Screenshot 2022-09-06 at 10 18 31" src="https://user-images.githubusercontent.com/25983129/188574112-6d161d1f-89c7-4605-b6a5-af5d14ab0e93.png">


