### PR TITLE
GRHB-445: * fix, change into courses-api getAll

### DIFF
--- a/mobile/src/services/courses-api/courses-api.service.ts
+++ b/mobile/src/services/courses-api/courses-api.service.ts
@@ -36,7 +36,7 @@ class Courses {
     filtering: CourseFilteringDto;
   }): Promise<CourseGetResponseDto[]> {
     return this.#http.load(
-      `${this.#apiPrefix}${ApiPath.COURSES}${CoursesApiPath.ROOT}`,
+      `${this.#apiPrefix}${ApiPath.COURSES}${CoursesApiPath.DASHBOARD}`,
       {
         method: HttpMethod.GET,
         queryParams: {


### PR DESCRIPTION
[1. Bug:  "'Title' is not allowed" error occurs at main page](https://trello.com/c/NXPOYv3X/445-title-is-not-allowed-error-occurs-at-main-page)