### PR TITLE
GRHB-358: * change the format of a date for note-card

### DIFF
--- a/mobile/src/components/interview/components/history/components/note-cards-list/components/note-card/note-card.tsx
+++ b/mobile/src/components/interview/components/history/components/note-cards-list/components/note-card/note-card.tsx
@@ -27,7 +27,7 @@ const NoteCard: FC<Props> = ({ note }) => {
       <View style={styles.textContainer}>
         <Text style={styles.note}>{note.note}</Text>
         <Text style={styles.date}>
-          {getFormattedDate(note.createdAt, 'HH:mm, dd.MM')}
+          {getFormattedDate(note.createdAt, 'HH:mm dd.MM.yyyy')}
         </Text>
       </View>
     </View>


### PR DESCRIPTION
1. [Bug: Date must be in the following format: hh:mm DD:MM:YYYY](https://trello.com/c/UlzyXcZ4/358-application-history)
2.  Result:
<img src="https://user-images.githubusercontent.com/82529236/189049375-7385e022-b1dc-4654-9000-77a0504c8f5e.png" width="45%">
