### PR TITLE
GRHB418: * fix input text color

### DIFF
--- a/frontend/src/components/common/select/styles.module.scss
+++ b/frontend/src/components/common/select/styles.module.scss
@@ -50,7 +50,6 @@
   appearance: none;
 }
 
-.select [class$='-Input'],
 .select [class$='-singleValue'] {
   color: var(--typography-text-100-inverse);
 }

--- a/frontend/src/components/common/select/styles.ts
+++ b/frontend/src/components/common/select/styles.ts
@@ -18,6 +18,10 @@ const DEFAULT_SELECT_STYLES: SelectStyles = {
     ...styles,
     backgroundColor: state.isFocused ? '#2563EB' : '#343646',
   }),
+  input: (styles: CSSObjectWithLabel): CSSObjectWithLabel => ({
+    ...styles,
+    color: 'var(--typography-text-100-inverse)',
+  }),
 };
 
 export { DEFAULT_SELECT_STYLES };


### PR DESCRIPTION
`[class$='-Input']` was not present on development so input styles were not applied and text was hardly visible