### PR TITLE
GRHB-510: * change page size for udemy api

### DIFF
--- a/backend/src/services/udemy/udemy.service.ts
+++ b/backend/src/services/udemy/udemy.service.ts
@@ -15,7 +15,7 @@ type Constructor = {
 };
 
 class Udemy {
-  #MODULE_API_PAGE_SIZE = 15;
+  #MODULE_API_PAGE_SIZE = 100;
 
   #INITIAL_PAGE = 1;
 


### PR DESCRIPTION
Max page size for requests to Udemy is 100. Fetching 15 by 15 will require more requests for a course with lots of modules