### PR TITLE
GRHB-514: * fixed last message display

### DIFF
--- a/frontend/src/components/chats/components/chats-list/components/chat/styles.module.scss
+++ b/frontend/src/components/chats/components/chats-list/components/chat/styles.module.scss
@@ -39,6 +39,10 @@
 }
 
 .lastMessage {
+  max-width: 320px;
   margin-top: 0;
+  overflow: hidden;
   color: var(--typography-text-gray-200);
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }

--- a/frontend/src/components/chats/components/chats-list/styles.module.scss
+++ b/frontend/src/components/chats/components/chats-list/styles.module.scss
@@ -1,7 +1,7 @@
 .listWrapper {
   display: flex;
   flex-direction: column;
-  min-width: 346px;
+  min-width: 450px;
   background: var(--background-gray-300);
 }
 


### PR DESCRIPTION
<img width="508" alt="image" src="https://user-images.githubusercontent.com/78655088/189696622-8135c067-5aec-4bbe-b6f7-c7ed29a032c7.png">

Last message is displayed with ellipsis on overflow