### PR TITLE
GRHB-411: User change image functionality

### DIFF
--- a/mobile/src/common/enums/notification/notification-message.enum.ts
+++ b/mobile/src/common/enums/notification/notification-message.enum.ts
@@ -6,6 +6,7 @@ enum NotificationMessage {
   UPDATE_SUCCESS = 'Successful update!',
   EDIT_CATEGORY_SUCCESS = 'Course category has been successfully updated!',
   PROFILE_AVATAR_UPDATE = 'Profile avatar was successfully updated!',
+  IMAGE_TO_BIG = 'Image size should be less than 1mb',
 }
 
 export { NotificationMessage };

--- a/mobile/src/components/setting/common/constants.ts
+++ b/mobile/src/components/setting/common/constants.ts
@@ -2,6 +2,7 @@ import { UserGender } from '~/common/enums/enums';
 import { UserDetailsUpdateInfoRequestDto } from '~/common/types/types';
 
 const SELECTION_LIMIT = 1;
+const AVATAR_MAX_SIZE = 1000000; // 1MB
 
 const DEFAULT_UPDATE_USER_DETAILS_PAYLOAD: UserDetailsUpdateInfoRequestDto = {
   fullName: '',
@@ -15,4 +16,9 @@ const GENDER_OPTIONS = Object.values(UserGender).map((gender) => ({
   value: gender,
 }));
 
-export { DEFAULT_UPDATE_USER_DETAILS_PAYLOAD, GENDER_OPTIONS, SELECTION_LIMIT };
+export {
+  AVATAR_MAX_SIZE,
+  DEFAULT_UPDATE_USER_DETAILS_PAYLOAD,
+  GENDER_OPTIONS,
+  SELECTION_LIMIT,
+};

--- a/mobile/src/components/setting/setting.tsx
+++ b/mobile/src/components/setting/setting.tsx
@@ -78,17 +78,15 @@ const Settings: FC = () => {
       return;
     }
 
-    if (image.fileSize) {
-      if (image.fileSize > AVATAR_MAX_SIZE) {
-        dispatch(
-          app.notify({
-            type: NotificationType.INFO,
-            message: NotificationMessage.IMAGE_TO_BIG,
-          }),
-        );
+    if (image.fileSize ?? 0 > AVATAR_MAX_SIZE) {
+      dispatch(
+        app.notify({
+          type: NotificationType.INFO,
+          message: NotificationMessage.IMAGE_TO_BIG,
+        }),
+      );
 
-        return;
-      }
+      return;
     }
 
     setSelectedImage(image);

--- a/mobile/src/components/setting/setting.tsx
+++ b/mobile/src/components/setting/setting.tsx
@@ -6,6 +6,8 @@ import {
   AuthScreenName,
   ButtonVariant,
   DataStatus,
+  NotificationMessage,
+  NotificationType,
   RootScreenName,
   UserAge,
   UserGender,
@@ -36,10 +38,11 @@ import {
   useEffect,
   useState,
 } from '~/hooks/hooks';
-import { authActions, userDetailsActions } from '~/store/actions';
+import { app, authActions, userDetailsActions } from '~/store/actions';
 import { userDetailsUpdateInfo as userDetailsUpdateInfoValidationSchema } from '~/validation-schemas/validation-schemas';
 
 import {
+  AVATAR_MAX_SIZE,
   DEFAULT_UPDATE_USER_DETAILS_PAYLOAD,
   GENDER_OPTIONS,
   SELECTION_LIMIT,
@@ -73,6 +76,19 @@ const Settings: FC = () => {
 
     if (!image) {
       return;
+    }
+
+    if (image.fileSize) {
+      if (image.fileSize > AVATAR_MAX_SIZE) {
+        dispatch(
+          app.notify({
+            type: NotificationType.INFO,
+            message: NotificationMessage.IMAGE_TO_BIG,
+          }),
+        );
+
+        return;
+      }
     }
 
     setSelectedImage(image);

--- a/mobile/src/components/setting/setting.tsx
+++ b/mobile/src/components/setting/setting.tsx
@@ -78,7 +78,7 @@ const Settings: FC = () => {
       return;
     }
 
-    if (image.fileSize ?? 0 > AVATAR_MAX_SIZE) {
+    if ((image.fileSize ?? 0) > AVATAR_MAX_SIZE) {
       dispatch(
         app.notify({
           type: NotificationType.INFO,


### PR DESCRIPTION
# Added validation for image large then 1mb
<img src="https://i.gyazo.com/e5986e28d829ba4da4b8f0bf1875f700.gif" width="60%">

### It makes no sense to do checks for image types because the image picker always returns jpeg format for all images except png (checked on such formats as webp, avif, svg)