### PR TITLE
GRHB-535:  + Capitalize gender dropdown options

### DIFF
--- a/mobile/src/components/setting/common/constants.ts
+++ b/mobile/src/components/setting/common/constants.ts
@@ -1,5 +1,6 @@
 import { UserGender } from '~/common/enums/enums';
 import { UserDetailsUpdateInfoRequestDto } from '~/common/types/types';
+import { capitalize } from '~/helpers/helpers';
 
 const SELECTION_LIMIT = 1;
 const AVATAR_MAX_SIZE = 1000000; // 1MB
@@ -12,7 +13,7 @@ const DEFAULT_UPDATE_USER_DETAILS_PAYLOAD: UserDetailsUpdateInfoRequestDto = {
 };
 
 const GENDER_OPTIONS = Object.values(UserGender).map((gender) => ({
-  label: gender,
+  label: capitalize(gender),
   value: gender,
 }));
 


### PR DESCRIPTION
[1. Bug: Capitalize gender dropdown options. Change `male` `female` `other` options to `Male` `Female` `Other`](https://trello.com/c/HDVCHIyX/535-capitalize-gender-dropdown-options-mobile)
2. Result:
<img src = "https://user-images.githubusercontent.com/82529236/190106444-9f526372-849f-4009-ad73-80c45e19f85a.png" width="70%">

