### PR TITLE
GRHB-538: Disable drawer gestures

### DIFF
--- a/mobile/src/common/types/navigation/navigation-item.type.ts
+++ b/mobile/src/common/types/navigation/navigation-item.type.ts
@@ -1,3 +1,4 @@
+import { DrawerNavigationOptions } from '@react-navigation/drawer';
 import React from 'react';
 
 import { PermissionKey } from '~/common/enums/enums';
@@ -7,6 +8,7 @@ type NavigationItem = {
   permissions: PermissionKey[];
   component: React.FC;
   isAuthRequired: boolean;
+  screenOptions?: DrawerNavigationOptions;
 };
 
 export { type NavigationItem };

--- a/mobile/src/common/types/navigation/navigation-item.type.ts
+++ b/mobile/src/common/types/navigation/navigation-item.type.ts
@@ -1,4 +1,3 @@
-import { DrawerNavigationOptions } from '@react-navigation/drawer';
 import React from 'react';
 
 import { PermissionKey } from '~/common/enums/enums';
@@ -8,7 +7,6 @@ type NavigationItem = {
   permissions: PermissionKey[];
   component: React.FC;
   isAuthRequired: boolean;
-  screenOptions?: DrawerNavigationOptions;
 };
 
 export { type NavigationItem };

--- a/mobile/src/navigation/app/app.navigation.tsx
+++ b/mobile/src/navigation/app/app.navigation.tsx
@@ -7,7 +7,7 @@ import { getPermittedScreens, getScreensByAuth } from '~/helpers/helpers';
 import { useAppSelector, useMemo } from '~/hooks/hooks';
 
 import { NAVIGATION_ITEMS, SCREEN_OPTIONS } from './common/constants/constants';
-import { DrawerNavigationItem } from './common/types/drawer-navigation-item.type';
+import { DrawerNavigationItem } from './common/types/types';
 import { DrawerContent } from './components/components';
 
 const Drawer = createDrawerNavigator<AppNavigationParamList>();
@@ -46,6 +46,7 @@ const App: FC = () => {
             key={screen.name}
             name={screen.name as AppScreenName}
             component={screen.component}
+            options={screen.screenOptions}
           />
         );
       })}

--- a/mobile/src/navigation/app/app.navigation.tsx
+++ b/mobile/src/navigation/app/app.navigation.tsx
@@ -17,7 +17,7 @@ const App: FC = () => {
 
   const userPermissions = user?.permissions ?? [];
 
-  const allowedScreens = useMemo(() => {
+  const allowedScreens: DrawerNavigationItem[] = useMemo(() => {
     const screensByAuth = getScreensByAuth(NAVIGATION_ITEMS, Boolean(user));
 
     const permittedScreens = getPermittedScreens(

--- a/mobile/src/navigation/app/common/constants/constants.ts
+++ b/mobile/src/navigation/app/common/constants/constants.ts
@@ -79,6 +79,9 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     ],
     isAuthRequired: true,
     drawerGroup: 'Menu',
+    screenOptions: {
+      swipeEdgeWidth: 10,
+    },
   },
   {
     name: AppScreenName.CHAT,
@@ -111,6 +114,9 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     permissions: [PermissionKey.MANAGE_UAM],
     isAuthRequired: true,
     drawerGroup: 'Account',
+    screenOptions: {
+      swipeEdgeWidth: 10,
+    },
   },
   {
     name: AppScreenName.UAM_GROUPS_CREATE,
@@ -118,6 +124,9 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     component: UAMConfigureGroup,
     permissions: [PermissionKey.MANAGE_UAM],
     isAuthRequired: true,
+    screenOptions: {
+      swipeEnabled: false,
+    },
   },
   {
     name: AppScreenName.UAM_GROUPS_EDIT,
@@ -125,6 +134,9 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     component: UAMConfigureGroup,
     permissions: [PermissionKey.MANAGE_UAM],
     isAuthRequired: true,
+    screenOptions: {
+      swipeEnabled: false,
+    },
   },
   {
     name: AppScreenName.ADD_COURSE,
@@ -164,6 +176,9 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
       PermissionKey.MANAGE_INTERVIEWS,
     ],
     isAuthRequired: true,
+    screenOptions: {
+      swipeEnabled: false,
+    },
   },
   {
     name: AppScreenName.CONVERSATION,

--- a/mobile/src/navigation/app/common/constants/constants.ts
+++ b/mobile/src/navigation/app/common/constants/constants.ts
@@ -125,7 +125,7 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     permissions: [PermissionKey.MANAGE_UAM],
     isAuthRequired: true,
     screenOptions: {
-      swipeEnabled: false,
+      swipeEdgeWidth: 10,
     },
   },
   {
@@ -135,7 +135,7 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     permissions: [PermissionKey.MANAGE_UAM],
     isAuthRequired: true,
     screenOptions: {
-      swipeEnabled: false,
+      swipeEdgeWidth: 10,
     },
   },
   {
@@ -177,7 +177,7 @@ const NAVIGATION_ITEMS: DrawerNavigationItem[] = [
     ],
     isAuthRequired: true,
     screenOptions: {
-      swipeEnabled: false,
+      swipeEdgeWidth: 10,
     },
   },
   {

--- a/mobile/src/navigation/app/common/types/drawer-navigation-item.type.ts
+++ b/mobile/src/navigation/app/common/types/drawer-navigation-item.type.ts
@@ -1,3 +1,5 @@
+import { DrawerNavigationOptions } from '@react-navigation/drawer';
+
 import { IconName, NavigationItem } from '~/common/types/types';
 
 import { DrawerGroup } from './drawer-group.type';
@@ -5,6 +7,7 @@ import { DrawerGroup } from './drawer-group.type';
 type DrawerNavigationItem = NavigationItem & {
   icon?: IconName;
   drawerGroup?: DrawerGroup;
+  screenOptions?: DrawerNavigationOptions;
 };
 
 export { type DrawerNavigationItem };


### PR DESCRIPTION
### On screens where there is a back button, disabled swiping completely on others, reduced the interaction area, if we remove it completely, then we need to add a close button to the open sidebar