### PR TITLE
GRHB-553: * date separator is placed below the respective messages

### DIFF
--- a/mobile/src/components/chat-conversation/components/messages-list/messages-list.tsx
+++ b/mobile/src/components/chat-conversation/components/messages-list/messages-list.tsx
@@ -41,7 +41,7 @@ const MessagesList: FC<Props> = ({ currentUserId, messages }) => {
             />
           </View>
         )}
-        renderSectionFooter={({ section: { title } }): ReactElement => (
+        renderSectionHeader={({ section: { title } }): ReactElement => (
           <DateSeparator messageTime={title} />
         )}
         ListEmptyComponent={(): ReactElement => (


### PR DESCRIPTION
[1. Bug: Message date separator is placed below the respective messages mobile](https://trello.com/c/y9ZZFD8I/553-message-date-separator-is-placed-below-the-respective-messages-mobile)
2.
Before              |  After
:-------------------------:|:-------------------------:
<img src ="https://user-images.githubusercontent.com/82529236/190183009-7803fba3-6f08-482e-84f2-744e18fce69a.png" width="60%">  |  <img src ="https://user-images.githubusercontent.com/82529236/190183119-8441dc66-3d93-490e-b0b1-17b8553e2f26.png" width="60%">