### PR TITLE
GRHB-532: * change NotificationType when image to big

### DIFF
--- a/mobile/src/components/setting/setting.tsx
+++ b/mobile/src/components/setting/setting.tsx
@@ -90,7 +90,7 @@ const Settings: FC = () => {
     if ((image.fileSize ?? 0) > AVATAR_MAX_SIZE) {
       dispatch(
         app.notify({
-          type: NotificationType.INFO,
+          type: NotificationType.ERROR,
           message: NotificationMessage.IMAGE_TO_BIG,
         }),
       );


### PR DESCRIPTION
[1. Bug: change the color of the notification  - it should be red . Also change the text Information to Error.](https://trello.com/c/8xXv9mfs/532-add-notifications-to-change-image-functionality-in-mobile)
2.
<img src ="https://user-images.githubusercontent.com/82529236/190404610-c7dbde59-66e2-4b95-9f26-f63d889efcb9.png" width="40%">