### PR TITLE
GRHB-627: * fix categories bar padding

### DIFF
--- a/mobile/src/components/courses/components/category-list/style.ts
+++ b/mobile/src/components/courses/components/category-list/style.ts
@@ -3,7 +3,8 @@ import { StyleSheet } from 'react-native';
 const styles = StyleSheet.create({
   container: {
     flexGrow: 0,
-    paddingHorizontal: 10,
+    marginLeft: 20,
+    marginRight: 10,
     marginTop: 10,
   },
 });


### PR DESCRIPTION
[1. Bug: Categories bar has smaller padding from edge of the screen than course cards](https://trello.com/c/DIUN5sTA/627-categories-bar-has-smaller-padding-from-edge-of-the-screen-than-course-cards)
2. Result:
<img src = "https://user-images.githubusercontent.com/82529236/190962896-dfa61f5b-2fd6-4b70-9dbe-d9c3307bb1f3.png" width="65%">
