### PR TITLE
GRHB-618: + breakpoints

### DIFF
--- a/frontend/src/components/dashboard/common.ts
+++ b/frontend/src/components/dashboard/common.ts
@@ -1,17 +1,33 @@
 import { CarouselResponsiveType } from 'common/types/types';
 
 const carouselResponsiveBreakpoints: CarouselResponsiveType = {
-  desktop: {
-    breakpoint: { max: 3000, min: 1480 },
+  desktop3XLarge: {
+    breakpoint: { max: 2870, min: 2560 },
+    items: 7,
+  },
+  desktop2XLarge: {
+    breakpoint: { max: 2560, min: 2250 },
+    items: 6,
+  },
+  desktopXLarge: {
+    breakpoint: { max: 2250, min: 1940 },
     items: 5,
   },
-  tablet: {
-    breakpoint: { max: 1480, min: 464 },
+  desktopLarge: {
+    breakpoint: { max: 1940, min: 1630 },
+    items: 4,
+  },
+  desktop: {
+    breakpoint: { max: 1630, min: 1320 },
     items: 3,
   },
-  mobile: {
-    breakpoint: { max: 464, min: 0 },
+  tablet: {
+    breakpoint: { max: 1320, min: 1010 },
     items: 2,
+  },
+  mobile: {
+    breakpoint: { max: 1010, min: 0 },
+    items: 1,
   },
 };
 

--- a/frontend/src/components/dashboard/styles.module.scss
+++ b/frontend/src/components/dashboard/styles.module.scss
@@ -32,10 +32,10 @@
 }
 
 .carouselElement {
-  margin-right: 10px;
+  padding: 0 5px;
 }
 
 .carouselWrapper {
-  padding: 30px;
+  padding: 25px;
   color: var(--typography-text-100-inverse);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61088675/191729215-b427e112-0223-4dc9-9af4-a5fd94cf6c2c.png)

I added new and more precise breakpoints. I was thinking about the helper, which would use `window.innerWidth` and calculate the number of items, but in that case we would need to listen to width changes and I didn't like this idea. At least because it would be a redundant listener most of the times.
If you can suggest a better solution, I would love to hear it